### PR TITLE
Basic Search Page

### DIFF
--- a/location/schema/search_spot.json
+++ b/location/schema/search_spot.json
@@ -14,12 +14,12 @@
     "lng": {
       "type": "number",
       "description": "Longitude of the center of the area requested.",
-      "minimum": -90,
-      "maximum": 90
+      "minimum": -180,
+      "maximum": 180
     },
     "rad": {
-      "type": "integer",
-      "description": "Search radius around the search point, in kilometers",
+      "type": "number",
+      "description": "Search radius around the search point, in one-hundredth of a degree.",
       "minimum": 0,
       "maximum": 1000
     },

--- a/location/src/utils.py
+++ b/location/src/utils.py
@@ -3,7 +3,7 @@ from flask import Response, make_response
 
 SEARCH_PARAMS_TYPE = {
     "lat": float,
-    "lng": int,
+    "lng": float,
     "rad": float,
     "level": list,
 }

--- a/webapp/.env
+++ b/webapp/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_WEB_SERVER_URL=https://api.how-to-sea.xyz
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=AIzaSyC-kUDnZj9GDtowLG8H-OBXPjlI_GRuNs4 # Can be public. Referrer restricted

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -4,6 +4,9 @@
 const nextConfig = {
   output: "export",
   reactStrictMode: true,
+  experimental: {
+    missingSuspenseWithCSRBailout: false,
+  },
 };
 
 module.exports = nextConfig;

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@vis.gl/react-google-maps": "^1.1.0",
         "dotenv": "^16.4.5",
         "next": "14.2.3",
         "react": "^18",
@@ -491,6 +492,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.55.11",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.55.11.tgz",
+      "integrity": "sha512-F3VuPtjKj4UGuyym75pqmgPBOHbT/i7I6/D+4DdtSzbeu2aWZG1ENwpbZOd46uO+PSAz9flJEhxxi+b4MVb4gQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -629,6 +636,20 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.1.0.tgz",
+      "integrity": "sha512-MxDIhCfPRzTQY1c6sS0GFg8Ukl40o13fkIKEaCN0cR1BIrV4LPo+EuCov9WElbe0bOo8MApx5qAbqBKOmLQyKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -1970,8 +1991,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -3040,6 +3060,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3859,6 +3885,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-places-autocomplete": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-places-autocomplete/-/react-places-autocomplete-7.3.0.tgz",
+      "integrity": "sha512-86wcHC69JATvWBnIS/yCsBHLtwzOGcnx3Ye94u74yTrz1jLRC/txkVDkf6rvC+Jq3zNe/tAg/W53x0EaH1ZPPw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.5.8"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.7"
+      }
     },
     "node_modules/react-spinners": {
       "version": "0.14.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@vis.gl/react-google-maps": "^1.1.0",
     "dotenv": "^16.4.5",
     "next": "14.2.3",
     "react": "^18",

--- a/webapp/src/app/page.jsx
+++ b/webapp/src/app/page.jsx
@@ -1,7 +1,22 @@
+"use client";
 import HomeSearchBar from "@/components/_home_components/HomeSearchBar";
 import SpotList from "@/components/_home_components/SpotList";
+import { APIProvider } from "@vis.gl/react-google-maps";
+import { useRouter } from "next/navigation";
 
 export default function HomePage() {
+  const router = useRouter();
+
+  function handleSearchRequest({ lat, lng, rad, level }) {
+    try {
+      const queryString = `?lat=${lat}&lng=${lng}&rad=${rad}&level=${level}`;
+      router.push(`/search${queryString}`);
+    } catch (error) {
+      console.log(error);
+      alert("Une erreur s'est produite.");
+      return;
+    }
+  }
   return (
     <>
       <div className="px-5 md:px-10 xl:px-20">
@@ -14,7 +29,9 @@ export default function HomePage() {
             plongée en France et dans les septs mers du Globe.
           </p>
         </div>
-        <HomeSearchBar />
+        <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}>
+          <HomeSearchBar handleSubmit={handleSearchRequest} />
+        </APIProvider>
         <SpotList />
       </div>
     </>

--- a/webapp/src/app/page.jsx
+++ b/webapp/src/app/page.jsx
@@ -29,7 +29,10 @@ export default function HomePage() {
             plongée en France et dans les septs mers du Globe.
           </p>
         </div>
-        <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}>
+        <APIProvider
+          language="fr"
+          apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
+        >
           <HomeSearchBar handleSubmit={handleSearchRequest} />
         </APIProvider>
         <SpotList />

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -1,0 +1,24 @@
+export default function SearchBar({ handleSubmit }) {
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <input type="text"></input>
+        <select id="rad">
+          <option value="0.9">1 km</option>
+          <option value="1.8">2 km</option>
+          <option value="4.5">5 km</option>
+          <option value="9">10 km</option>
+          <option value="18">20 km</option>
+          <option value="90">50 km</option>
+        </select>
+        <select id="level">
+          <option value="all">Tous niveaux</option>
+          <option value="easy">Facile</option>
+          <option value="medium">Moyen</option>
+          <option value="hard">Difficile</option>
+        </select>
+        <button type="submit">Rechercher</button>
+      </form>
+    </>
+  );
+}

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -69,7 +69,6 @@ export default function SearchBar({ handleSubmit }) {
     <>
       <form className="flex" onSubmit={onSubmit}>
         <PlaceAutocomplete
-          // onChange={onChangeLocationField}
           onPlaceSelect={onPlaceSelect}
           onChange={onChangePlaceField}
         >
@@ -123,13 +122,3 @@ const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
     </div>
   );
 };
-
-/*
-Could create a place.PlacesServices object
-Take input field state 
-run findPlaceFromQuery and take first one
-update input field
-update formData
-
-problem is that it would make it run twice if user did select autocomplete
-*/

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -1,38 +1,89 @@
-import useSearchSpotForm from "../utils/useSearchSpotForm";
-import PlaceAutocomplete from "../utils/PlaceAutocomplete";
-import { levelOptions, radiusOptions } from "@/app/utils/spotSearchOptions";
+"use client";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import useSearchSpotForm from "@/app/utils/useSearchSpotForm";
+import PlaceAutocomplete from "@/app/utils/PlaceAutocomplete";
+import { radiusOptions, levelOptions } from "@/app/utils/spotSearchOptions";
 
-export default function SearchBar({ handleSubmit }) {
+export default function HomeSearchBar({ handleSubmit }) {
   const { placeField, onSubmit, onPlaceSelect, onChangePlaceField } =
     useSearchSpotForm(handleSubmit);
 
   return (
     <>
-      <form className="flex" onSubmit={onSubmit}>
-        <PlaceAutocomplete
-          onPlaceSelect={onPlaceSelect}
-          onChange={onChangePlaceField}
-          placeholder="Où veux-tu plonger?"
-        >
-          {placeField}
-        </PlaceAutocomplete>
+      <form
+        className="rounder-md my-3 inline-flex items-center border-slate-200 bg-slate-100 px-2"
+        onSubmit={onSubmit}
+      >
+        <FormInput
+          myLabel={<Label>Lieu</Label>}
+          myInput={
+            <PlaceAutocomplete
+              onPlaceSelect={onPlaceSelect}
+              onChange={onChangePlaceField}
+              placeholder="Où veux-tu plonger?"
+            >
+              {placeField}
+            </PlaceAutocomplete>
+          }
+        />
+        <FormInput
+          myLabel={<Label>Distance</Label>}
+          myInput={
+            <select
+              className="w-32 rounded-md border-[1px] border-gray-200 bg-slate-50 p-1"
+              id="rad"
+            >
+              {radiusOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          }
+        />
+        <FormInput
+          myLabel={<Label>Niveau</Label>}
+          myInput={
+            <select
+              className="w-32 rounded-md border-[1px] border-gray-200 bg-slate-50 p-1"
+              id="level"
+            >
+              {levelOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          }
+        />
 
-        <select id="rad">
-          {radiusOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <select id="level">
-          {levelOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        <button type="submit">Rechercher</button>
+        <div className="bg-gradient-to-r my-2 flex items-center justify-center rounded-xl bg-blue-400 px-5 py-3 text-white md:mr-2 md:rounded-lg">
+          <button type="submit" className="flex items-center">
+            <FontAwesomeIcon icon={faMagnifyingGlass} className="mr-2" />
+            Rechercher
+          </button>
+        </div>
       </form>
     </>
+  );
+}
+
+function Label({ children, myHtmlFor }) {
+  return (
+    <label
+      className="mb-1.5 text-xs font-semibold uppercase"
+      htmlFor={myHtmlFor}
+    >
+      {children}
+    </label>
+  );
+}
+function FormInput({ myLabel, myInput }) {
+  return (
+    <div className="flex w-full flex-1 flex-col flex-wrap rounded-xl bg-inherit bg-white px-4 py-3 md:bg-transparent">
+      {myLabel}
+      {myInput}
+    </div>
   );
 }

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -1,69 +1,24 @@
-import { useMapsLibrary } from "@vis.gl/react-google-maps";
-import { useEffect, useRef, useState } from "react";
+import useSearchSpotForm from "../utils/useSearchSpotForm";
+import PlaceAutocomplete from "../utils/PlaceAutocomplete";
+
+const radiusOptions = [
+  { value: "0.9", label: "1 km" },
+  { value: "1.8", label: "2 km" },
+  { value: "4.5", label: "5 km" },
+  { value: "9", label: "10 km" },
+  { value: "18", label: "20 km" },
+  { value: "90", label: "50 km" },
+];
+
+const levelOptions = [
+  { value: "easy", label: "Facile" },
+  { value: "medium", label: "Moyen" },
+  { value: "hard", label: "Difficile" },
+];
 
 export default function SearchBar({ handleSubmit }) {
-  const [inputData, setInputData] = useState({ lat: 0, lng: 0, rad: "1" });
-  const [placeField, setPlaceField] = useState("");
-  const [placesService, setPlacesService] = useState(null);
-  const places = useMapsLibrary("places");
-
-  useEffect(() => {
-    if (!places) return;
-    const service = new places.PlacesService(document.createElement("div"));
-    setPlacesService(service);
-  }, [places]);
-
-  async function onSubmit(e) {
-    e.preventDefault();
-    const res = await getPlaceFromInput(placeField);
-    const selectedPlaceRes = res[0];
-
-    const newInputData = {
-      ...inputData,
-      lat: selectedPlaceRes.geometry.location.lat(),
-      lng: selectedPlaceRes.geometry.location.lng(),
-      rad: e.target.elements.rad.value,
-      level: e.target.elements.level.value,
-    };
-    const displayAddress = resolveDisplayAddress(selectedPlaceRes);
-    setPlaceField(displayAddress);
-    setInputData(newInputData);
-    handleSubmit(newInputData);
-  }
-
-  function onPlaceSelect(val) {
-    // Expects a PlaceResult Object https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
-    const displayAddress = resolveDisplayAddress(val);
-    setPlaceField(displayAddress);
-  }
-
-  async function getPlaceFromInput(val) {
-    const request = {
-      fields: ["geometry", "formatted_address", "name"],
-      query: val,
-    };
-
-    return new Promise((resolve, reject) => {
-      placesService.findPlaceFromQuery(request, (arrPlaceResults, status) => {
-        if (status === google.maps.places.PlacesServiceStatus.OK) {
-          resolve(arrPlaceResults);
-        } else {
-          reject(status);
-        }
-      });
-    });
-  }
-
-  function resolveDisplayAddress(placeRes) {
-    // Autocomplete widget displays different addresses than the formatted address returned. https://stackoverflow.com/questions/50275296/google-maps-autocomplete-formatted-address-is-not-the-same-as-the-displayed-one
-    return placeRes.formatted_address.includes(`${placeRes.name}`)
-      ? placeRes.formatted_address
-      : `${placeRes.name}, ${placeRes.formatted_address}`;
-  }
-
-  function onChangePlaceField(e) {
-    setPlaceField(e.target.value);
-  }
+  const { placeField, onSubmit, onPlaceSelect, onChangePlaceField } =
+    useSearchSpotForm(handleSubmit);
 
   return (
     <>
@@ -76,49 +31,21 @@ export default function SearchBar({ handleSubmit }) {
         </PlaceAutocomplete>
 
         <select id="rad">
-          <option value="0.9">1 km</option>
-          <option value="1.8">2 km</option>
-          <option value="4.5">5 km</option>
-          <option value="9">10 km</option>
-          <option value="18">20 km</option>
-          <option value="90">50 km</option>
+          {radiusOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
         <select id="level">
-          <option value="easy">Facile</option>
-          <option value="medium">Moyen</option>
-          <option value="hard">Difficile</option>
+          {levelOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
         <button type="submit">Rechercher</button>
       </form>
     </>
   );
 }
-
-const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
-  const [placeAutocomplete, setPlaceAutocomplete] = useState(null);
-  const inputRef = useRef(null);
-  const places = useMapsLibrary("places");
-
-  useEffect(() => {
-    if (!places || !inputRef.current) return;
-
-    const options = {
-      fields: ["geometry", "name", "formatted_address"],
-    };
-
-    setPlaceAutocomplete(new places.Autocomplete(inputRef.current, options));
-  }, [places]);
-
-  useEffect(() => {
-    if (!placeAutocomplete) return;
-
-    placeAutocomplete.addListener("place_changed", () => {
-      onPlaceSelect(placeAutocomplete.getPlace());
-    });
-  }, [placeAutocomplete]);
-  return (
-    <div className="autocomplete-container">
-      <input ref={inputRef} onChange={onChange} value={children} />
-    </div>
-  );
-};

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -12,7 +12,7 @@ export default function HomeSearchBar({ handleSubmit }) {
   return (
     <>
       <form
-        className="rounder-md my-3 inline-flex items-center border-slate-200 bg-slate-100 px-2"
+        className="my-3 inline-flex items-center rounded-lg border-slate-200 bg-slate-100 px-2"
         onSubmit={onSubmit}
       >
         <FormInput

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -1,8 +1,72 @@
+import { useMapsLibrary } from "@vis.gl/react-google-maps";
+import { useEffect, useRef, useState } from "react";
+
 export default function SearchBar({ handleSubmit }) {
+  const [inputData, setInputData] = useState({ lat: 0, lng: 0, rad: "1" });
+  const [placeField, setPlaceField] = useState("");
+  const [placesService, setPlacesService] = useState(null);
+  const places = useMapsLibrary("places");
+
+  useEffect(() => {
+    if (!places) return;
+    const service = new places.PlacesService(document.createElement("div"));
+    setPlacesService(service);
+  }, [places]);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    const res = await getPlaceFromInput(placeField);
+    const selectedPlaceRes = res[0];
+
+    const newInputData = {
+      ...inputData,
+      lat: selectedPlaceRes.geometry.location.lat(),
+      lng: selectedPlaceRes.geometry.location.lng(),
+      rad: e.target.elements.rad.value,
+      level: e.target.elements.level.value,
+    };
+    setPlaceField(selectedPlaceRes.formatted_address);
+    setInputData(newInputData);
+    handleSubmit(newInputData);
+  }
+
+  async function getPlaceFromInput(val) {
+    const request = {
+      fields: ["geometry", "formatted_address"],
+      query: val,
+    };
+
+    return new Promise((resolve, reject) => {
+      placesService.findPlaceFromQuery(request, (arrPlaceResults, status) => {
+        if (status === google.maps.places.PlacesServiceStatus.OK) {
+          resolve(arrPlaceResults);
+        } else {
+          reject(status);
+        }
+      });
+    });
+  }
+
+  function onPlaceSelect(val) {
+    // Expects a PlaceResult Object https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
+    setPlaceField(val.formatted_address);
+  }
+
+  function onChangePlaceField(e) {
+    setPlaceField(e.target.value);
+  }
+
   return (
     <>
-      <form onSubmit={handleSubmit}>
-        <input type="text"></input>
+      <form className="flex" onSubmit={onSubmit}>
+        <PlaceAutocomplete
+          // onChange={onChangeLocationField}
+          onPlaceSelect={onPlaceSelect}
+          onChange={onChangePlaceField}
+        >
+          {placeField}
+        </PlaceAutocomplete>
+
         <select id="rad">
           <option value="0.9">1 km</option>
           <option value="1.8">2 km</option>
@@ -12,7 +76,6 @@ export default function SearchBar({ handleSubmit }) {
           <option value="90">50 km</option>
         </select>
         <select id="level">
-          <option value="all">Tous niveaux</option>
           <option value="easy">Facile</option>
           <option value="medium">Moyen</option>
           <option value="hard">Difficile</option>
@@ -22,3 +85,42 @@ export default function SearchBar({ handleSubmit }) {
     </>
   );
 }
+
+const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
+  const [placeAutocomplete, setPlaceAutocomplete] = useState(null);
+  const inputRef = useRef(null);
+  const places = useMapsLibrary("places");
+
+  useEffect(() => {
+    if (!places || !inputRef.current) return;
+
+    const options = {
+      fields: ["geometry", "name", "formatted_address"],
+    };
+
+    setPlaceAutocomplete(new places.Autocomplete(inputRef.current, options));
+  }, [places]);
+
+  useEffect(() => {
+    if (!placeAutocomplete) return;
+
+    placeAutocomplete.addListener("place_changed", () => {
+      onPlaceSelect(placeAutocomplete.getPlace());
+    });
+  }, [placeAutocomplete]);
+  return (
+    <div className="autocomplete-container">
+      <input ref={inputRef} onChange={onChange} value={children} />
+    </div>
+  );
+};
+
+/*
+Could create a place.PlacesServices object
+Take input field state 
+run findPlaceFromQuery and take first one
+update input field
+update formData
+
+problem is that it would make it run twice if user did select autocomplete
+*/

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -1,20 +1,6 @@
 import useSearchSpotForm from "../utils/useSearchSpotForm";
 import PlaceAutocomplete from "../utils/PlaceAutocomplete";
-
-const radiusOptions = [
-  { value: "0.9", label: "1 km" },
-  { value: "1.8", label: "2 km" },
-  { value: "4.5", label: "5 km" },
-  { value: "9", label: "10 km" },
-  { value: "18", label: "20 km" },
-  { value: "90", label: "50 km" },
-];
-
-const levelOptions = [
-  { value: "easy", label: "Facile" },
-  { value: "medium", label: "Moyen" },
-  { value: "hard", label: "Difficile" },
-];
+import { levelOptions, radiusOptions } from "@/app/utils/spotSearchOptions";
 
 export default function SearchBar({ handleSubmit }) {
   const { placeField, onSubmit, onPlaceSelect, onChangePlaceField } =
@@ -26,6 +12,7 @@ export default function SearchBar({ handleSubmit }) {
         <PlaceAutocomplete
           onPlaceSelect={onPlaceSelect}
           onChange={onChangePlaceField}
+          placeholder="Où veux-tu plonger?"
         >
           {placeField}
         </PlaceAutocomplete>

--- a/webapp/src/app/search/SearchBar.jsx
+++ b/webapp/src/app/search/SearchBar.jsx
@@ -25,14 +25,21 @@ export default function SearchBar({ handleSubmit }) {
       rad: e.target.elements.rad.value,
       level: e.target.elements.level.value,
     };
-    setPlaceField(selectedPlaceRes.formatted_address);
+    const displayAddress = resolveDisplayAddress(selectedPlaceRes);
+    setPlaceField(displayAddress);
     setInputData(newInputData);
     handleSubmit(newInputData);
   }
 
+  function onPlaceSelect(val) {
+    // Expects a PlaceResult Object https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
+    const displayAddress = resolveDisplayAddress(val);
+    setPlaceField(displayAddress);
+  }
+
   async function getPlaceFromInput(val) {
     const request = {
-      fields: ["geometry", "formatted_address"],
+      fields: ["geometry", "formatted_address", "name"],
       query: val,
     };
 
@@ -47,9 +54,11 @@ export default function SearchBar({ handleSubmit }) {
     });
   }
 
-  function onPlaceSelect(val) {
-    // Expects a PlaceResult Object https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
-    setPlaceField(val.formatted_address);
+  function resolveDisplayAddress(placeRes) {
+    // Autocomplete widget displays different addresses than the formatted address returned. https://stackoverflow.com/questions/50275296/google-maps-autocomplete-formatted-address-is-not-the-same-as-the-displayed-one
+    return placeRes.formatted_address.includes(`${placeRes.name}`)
+      ? placeRes.formatted_address
+      : `${placeRes.name}, ${placeRes.formatted_address}`;
   }
 
   function onChangePlaceField(e) {

--- a/webapp/src/app/search/SearchResult.jsx
+++ b/webapp/src/app/search/SearchResult.jsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+export default function SearchResult({ data }) {
+  function mapLevel(level) {
+    switch (level) {
+      case "easy":
+        return "facile";
+      case "medium":
+        return "intermédiaire";
+      case "hard":
+        return "Avancé";
+    }
+  }
+  return (
+    <>
+      <Link
+        href={`/spot/${data._id.$oid}`}
+        className="flex min-w-[250px] shrink grow basis-1/3 flex-col lg:my-5 lg:flex-row"
+      >
+        <div className="flex h-full max-h-[250px] shrink-0 justify-center overflow-hidden rounded-lg lg:max-h-[200px] lg:w-[300px]">
+          <img className="object-cover" alt={data.title} src={data.image[0]} />
+        </div>
+        <div className="my-3 flex h-[80px] flex-col justify-between overflow-hidden lg:mx-3 lg:my-0 lg:h-auto">
+          <div>
+            <div className="flex w-full justify-between">
+              <p className="text-lg">{data.title}</p>
+              <p>4.8 X</p>
+            </div>
+            <p className="font-light text-[#6A6A6A]">
+              {data.address.city}, {data.address.country}
+            </p>
+
+            <p className="w-100 my-2 hidden font-light text-[#6A6A6A] lg:line-clamp-3">
+              {data.description}
+            </p>
+          </div>
+          <p className="capitalize">{mapLevel(data.level)}, Keywords</p>
+        </div>
+      </Link>
+      <hr className="last:hidden" />
+    </>
+  );
+}

--- a/webapp/src/app/search/SearchResultsContainer.jsx
+++ b/webapp/src/app/search/SearchResultsContainer.jsx
@@ -8,7 +8,12 @@ export default function SearchResultsContainer({ status, data }) {
     let content = <></>;
 
     if (data.length == 0) {
-      content = <p>Pas de résultat trouvé</p>;
+      content = (
+        <p>
+          Pas de résultat trouvé <br /> Pour obtenir plus de résultat, essayer
+          d&apos;ajuster la zone de recherche.
+        </p>
+      );
     } else {
       content = (
         <div className="flex flex-row flex-wrap gap-4 lg:flex-col lg:gap-0">
@@ -26,7 +31,7 @@ export default function SearchResultsContainer({ status, data }) {
     );
   }
   function renderError() {
-    return <p>Une erreur s'est produite</p>;
+    return <p>Une erreur s&apos;est produite</p>;
   }
 
   function renderContent() {

--- a/webapp/src/app/search/SearchResultsContainer.jsx
+++ b/webapp/src/app/search/SearchResultsContainer.jsx
@@ -1,0 +1,45 @@
+import SearchResult from "./SearchResult";
+
+export default function SearchResultsContainer({ status, data }) {
+  function renderLoading() {
+    return <p>Recherche en cours</p>;
+  }
+  function renderSuccess() {
+    let content = <></>;
+
+    if (data.length == 0) {
+      content = <p>Pas de résultat trouvé</p>;
+    } else {
+      content = (
+        <div className="flex flex-row flex-wrap gap-4 lg:flex-col lg:gap-0">
+          {data.map((result) => (
+            <SearchResult key={result._id.$oid} data={result} />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <>
+        <h1 className="text-2xl">Resultat de votre recherche</h1>
+        {content}
+      </>
+    );
+  }
+  function renderError() {
+    return <p>Une erreur s'est produite</p>;
+  }
+
+  function renderContent() {
+    switch (status) {
+      case "loading":
+        return renderLoading();
+      case "success":
+        return renderSuccess();
+
+      default:
+        return renderError();
+    }
+  }
+
+  return <div className="min-h-[60vh]">{renderContent()}</div>;
+}

--- a/webapp/src/app/search/page.jsx
+++ b/webapp/src/app/search/page.jsx
@@ -1,33 +1,51 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import SearchResultsContainer from "./SearchResultsContainer";
+import SearchBar from "./SearchBar";
 
 export default function SearchPage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [queryResults, setQueryResults] = useState(null);
   const [queryStatus, setQueryStatus] = useState("loading");
+  const [queryResults, setQueryResults] = useState(null);
+
   useEffect(() => {
-    console.log("effect called");
-    makeSearchQuery().then((r) => {
-      //TODO: Validate data before setting query result
-      setQueryResults(r);
-    });
+    fetchLocation(searchParams.toString())
+      .then((r) => {
+        setQueryResults(r);
+      })
+      .catch((e) => {
+        setQueryStatus("error");
+      });
   }, [searchParams]); // Makes a search query to /location/search. Depends on query params found
 
   function handleSearch(e) {
-    router.push(`${pathname}?lat=43&lng=7&rad=100&level=hard`); // MOCK
-  } // update query params, which should trigger search useEffect
+    // update searchParams, which should trigger search useEffect
+    e.preventDefault();
 
-  async function makeSearchQuery() {
-    const test = `?${searchParams.toString()}`;
+    try {
+      const rad = e.target.elements.rad.value;
+      const level = e.target.elements.level.value;
+      const lat = 43;
+      const lng = 7;
+
+      const queryString = `?lat=${lat}&lng=${lng}&rad=${rad}&level=${level}`;
+      router.push(`${pathname}${queryString}`);
+    } catch (error) {
+      alert("Une erreur s'est produite.");
+      return;
+    }
+  }
+
+  async function fetchLocation(searchParamsStr) {
+    setQueryStatus("loading");
     const options = {
       method: "GET",
       headers: { "Content-Type": "application/json" },
     };
-    const url = `${process.env.NEXT_PUBLIC_WEB_SERVER_URL}/location/search${test}`;
+    const url = `${process.env.NEXT_PUBLIC_WEB_SERVER_URL}/location/search?${searchParamsStr}`;
 
     try {
       const response = await fetch(url, options);
@@ -35,6 +53,11 @@ export default function SearchPage() {
         throw new Error("Network response was not ok " + response.statusText);
       }
       let a = await response.json();
+
+      if (!validateQueryResult(a.data)) {
+        throw new Error("Invalid result: " + a.data);
+      }
+
       setQueryStatus("success");
       return a.data;
     } catch (error) {
@@ -43,10 +66,17 @@ export default function SearchPage() {
       return null;
     }
   }
-
+  function validateQueryResult(resultObj) {
+    // Can be expanded further.
+    if (!Array.isArray(resultObj)) {
+      return false;
+    }
+    return true;
+  }
   return (
     <>
       <div className="px-5 md:px-10 xl:px-20">
+        <SearchBar handleSubmit={handleSearch} />
         <SearchResultsContainer status={queryStatus} data={queryResults} />
       </div>
     </>

--- a/webapp/src/app/search/page.jsx
+++ b/webapp/src/app/search/page.jsx
@@ -1,0 +1,54 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import SearchResultsContainer from "./SearchResultsContainer";
+
+export default function SearchPage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [queryResults, setQueryResults] = useState(null);
+  const [queryStatus, setQueryStatus] = useState("loading");
+  useEffect(() => {
+    console.log("effect called");
+    makeSearchQuery().then((r) => {
+      //TODO: Validate data before setting query result
+      setQueryResults(r);
+    });
+  }, [searchParams]); // Makes a search query to /location/search. Depends on query params found
+
+  function handleSearch(e) {
+    router.push(`${pathname}?lat=43&lng=7&rad=100&level=hard`); // MOCK
+  } // update query params, which should trigger search useEffect
+
+  async function makeSearchQuery() {
+    const test = `?${searchParams.toString()}`;
+    const options = {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    };
+    const url = `${process.env.NEXT_PUBLIC_WEB_SERVER_URL}/location/search${test}`;
+
+    try {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        throw new Error("Network response was not ok " + response.statusText);
+      }
+      let a = await response.json();
+      setQueryStatus("success");
+      return a.data;
+    } catch (error) {
+      console.error("An error occured while talking to the server.", error);
+      setQueryStatus("error");
+      return null;
+    }
+  }
+
+  return (
+    <>
+      <div className="px-5 md:px-10 xl:px-20">
+        <SearchResultsContainer status={queryStatus} data={queryResults} />
+      </div>
+    </>
+  );
+}

--- a/webapp/src/app/search/page.jsx
+++ b/webapp/src/app/search/page.jsx
@@ -23,8 +23,6 @@ export default function SearchPage() {
   }, [searchParams]); // Makes a search query to /location/search. Depends on query params found
 
   function handleSearchRequest({ lat, lng, rad, level }) {
-    // update searchParams, which should trigger search useEffect
-
     try {
       const queryString = `?lat=${lat}&lng=${lng}&rad=${rad}&level=${level}`;
       router.push(`${pathname}${queryString}`);

--- a/webapp/src/app/search/page.jsx
+++ b/webapp/src/app/search/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { APIProvider } from "@vis.gl/react-google-maps";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import SearchResultsContainer from "./SearchResultsContainer";
 import SearchBar from "./SearchBar";
@@ -21,16 +22,10 @@ export default function SearchPage() {
       });
   }, [searchParams]); // Makes a search query to /location/search. Depends on query params found
 
-  function handleSearch(e) {
+  function handleSearchRequest({ lat, lng, rad, level }) {
     // update searchParams, which should trigger search useEffect
-    e.preventDefault();
 
     try {
-      const rad = e.target.elements.rad.value;
-      const level = e.target.elements.level.value;
-      const lat = 43;
-      const lng = 7;
-
       const queryString = `?lat=${lat}&lng=${lng}&rad=${rad}&level=${level}`;
       router.push(`${pathname}${queryString}`);
     } catch (error) {
@@ -75,10 +70,12 @@ export default function SearchPage() {
   }
   return (
     <>
-      <div className="px-5 md:px-10 xl:px-20">
-        <SearchBar handleSubmit={handleSearch} />
-        <SearchResultsContainer status={queryStatus} data={queryResults} />
-      </div>
+      <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}>
+        <div className="px-5 md:px-10 xl:px-20">
+          <SearchBar handleSubmit={handleSearchRequest} />
+          <SearchResultsContainer status={queryStatus} data={queryResults} />
+        </div>
+      </APIProvider>
     </>
   );
 }

--- a/webapp/src/app/search/page.jsx
+++ b/webapp/src/app/search/page.jsx
@@ -68,7 +68,10 @@ export default function SearchPage() {
   }
   return (
     <>
-      <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}>
+      <APIProvider
+        language="fr"
+        apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
+      >
         <div className="px-5 md:px-10 xl:px-20">
           <SearchBar handleSubmit={handleSearchRequest} />
           <SearchResultsContainer status={queryStatus} data={queryResults} />

--- a/webapp/src/app/utils/PlaceAutocomplete.jsx
+++ b/webapp/src/app/utils/PlaceAutocomplete.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from "react";
+import { useMapsLibrary } from "@vis.gl/react-google-maps";
+
+const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
+  const [placeAutocomplete, setPlaceAutocomplete] = useState(null);
+  const inputRef = useRef(null);
+  const places = useMapsLibrary("places");
+
+  useEffect(() => {
+    if (!places || !inputRef.current) return;
+
+    const options = {
+      fields: ["geometry", "name", "formatted_address"],
+    };
+
+    setPlaceAutocomplete(new places.Autocomplete(inputRef.current, options));
+  }, [places]);
+
+  useEffect(() => {
+    if (!placeAutocomplete) return;
+
+    placeAutocomplete.addListener("place_changed", () => {
+      onPlaceSelect(placeAutocomplete.getPlace());
+    });
+  }, [placeAutocomplete]);
+  return (
+    <div className="autocomplete-container">
+      <input ref={inputRef} onChange={onChange} value={children} />
+    </div>
+  );
+};
+
+export default PlaceAutocomplete;

--- a/webapp/src/app/utils/PlaceAutocomplete.jsx
+++ b/webapp/src/app/utils/PlaceAutocomplete.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { useMapsLibrary } from "@vis.gl/react-google-maps";
 
-const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
+const PlaceAutocomplete = ({
+  children,
+  onPlaceSelect,
+  onChange,
+  placeholder,
+}) => {
   const [placeAutocomplete, setPlaceAutocomplete] = useState(null);
   const inputRef = useRef(null);
   const places = useMapsLibrary("places");
@@ -25,7 +30,12 @@ const PlaceAutocomplete = ({ children, onPlaceSelect, onChange }) => {
   }, [placeAutocomplete]);
   return (
     <div className="autocomplete-container">
-      <input ref={inputRef} onChange={onChange} value={children} />
+      <input
+        ref={inputRef}
+        onChange={onChange}
+        value={children}
+        placeholder={placeholder || ""}
+      />
     </div>
   );
 };

--- a/webapp/src/app/utils/spotSearchOptions.js
+++ b/webapp/src/app/utils/spotSearchOptions.js
@@ -9,8 +9,8 @@ const radiusOptions = [
 
 const levelOptions = [
   { value: "easy", label: "Facile" },
-  { value: "medium", label: "Moyen" },
-  { value: "hard", label: "Difficile" },
+  { value: "medium", label: "Intermédiaire" },
+  { value: "hard", label: "Avancé" },
 ];
 
 export { levelOptions, radiusOptions };

--- a/webapp/src/app/utils/spotSearchOptions.js
+++ b/webapp/src/app/utils/spotSearchOptions.js
@@ -1,0 +1,16 @@
+const radiusOptions = [
+  { value: "0.9", label: "1 km" },
+  { value: "1.8", label: "2 km" },
+  { value: "4.5", label: "5 km" },
+  { value: "9", label: "10 km" },
+  { value: "18", label: "20 km" },
+  { value: "90", label: "50 km" },
+];
+
+const levelOptions = [
+  { value: "easy", label: "Facile" },
+  { value: "medium", label: "Moyen" },
+  { value: "hard", label: "Difficile" },
+];
+
+export { levelOptions, radiusOptions };

--- a/webapp/src/app/utils/useSearchSpotForm.jsx
+++ b/webapp/src/app/utils/useSearchSpotForm.jsx
@@ -1,0 +1,76 @@
+import { useMapsLibrary } from "@vis.gl/react-google-maps";
+import { useEffect, useState } from "react";
+
+export default function useSearchSpotForm(handleSubmit) {
+  // Defines the state and logic to produce the correct input when submitting the form
+  const [inputData, setInputData] = useState({ lat: 0, lng: 0, rad: "1" });
+  const [placeField, setPlaceField] = useState("");
+  const [placesService, setPlacesService] = useState(null);
+  const places = useMapsLibrary("places");
+
+  useEffect(() => {
+    if (!places) return;
+    const service = new places.PlacesService(document.createElement("div"));
+    setPlacesService(service);
+  }, [places]);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    const res = await getPlaceFromInput(placeField);
+    const selectedPlaceRes = res[0];
+
+    const newInputData = {
+      ...inputData,
+      lat: selectedPlaceRes.geometry.location.lat(),
+      lng: selectedPlaceRes.geometry.location.lng(),
+      rad: e.target.elements.rad.value,
+      level: e.target.elements.level.value,
+    };
+    const displayAddress = resolveDisplayAddress(selectedPlaceRes);
+    setPlaceField(displayAddress);
+    setInputData(newInputData);
+    handleSubmit(newInputData);
+  }
+
+  function onPlaceSelect(val) {
+    // Expects a PlaceResult Object https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
+    const displayAddress = resolveDisplayAddress(val);
+    setPlaceField(displayAddress);
+  }
+
+  async function getPlaceFromInput(val) {
+    const request = {
+      fields: ["geometry", "formatted_address", "name"],
+      query: val,
+    };
+
+    return new Promise((resolve, reject) => {
+      placesService.findPlaceFromQuery(request, (arrPlaceResults, status) => {
+        if (status === google.maps.places.PlacesServiceStatus.OK) {
+          resolve(arrPlaceResults);
+        } else {
+          reject(status);
+        }
+      });
+    });
+  }
+
+  function resolveDisplayAddress(placeRes) {
+    // Autocomplete widget displays different addresses than the formatted address returned. https://stackoverflow.com/questions/50275296/google-maps-autocomplete-formatted-address-is-not-the-same-as-the-displayed-one
+    return placeRes.formatted_address.includes(`${placeRes.name}`)
+      ? placeRes.formatted_address
+      : `${placeRes.name}, ${placeRes.formatted_address}`;
+  }
+
+  function onChangePlaceField(e) {
+    setPlaceField(e.target.value);
+  }
+
+  return {
+    inputData,
+    placeField,
+    onSubmit,
+    onPlaceSelect,
+    onChangePlaceField,
+  };
+}

--- a/webapp/src/components/Header.jsx
+++ b/webapp/src/components/Header.jsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Header() {
   return (
     <>
-      <div className="mb-10 bg-white px-1 py-1 shadow-sm md:px-10 xl:px-20">
+      <div className="bg-white px-1 py-1 shadow-sm md:px-10 xl:px-20">
         <Link
           className="flex basis-full items-center justify-center md:justify-start"
           href="/"

--- a/webapp/src/components/_home_components/HomeSearchBar.jsx
+++ b/webapp/src/components/_home_components/HomeSearchBar.jsx
@@ -1,7 +1,13 @@
+"use client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import useSearchSpotForm from "@/app/utils/useSearchSpotForm";
+import PlaceAutocomplete from "@/app/utils/PlaceAutocomplete";
+import { levelOptions } from "@/app/utils/spotSearchOptions";
 
-export default function HomeSearchBar() {
+export default function HomeSearchBar({ handleSubmit }) {
+  const { placeField, onSubmit, onPlaceSelect, onChangePlaceField } =
+    useSearchSpotForm(handleSubmit);
   return (
     <>
       <div
@@ -11,22 +17,35 @@ export default function HomeSearchBar() {
         <form
           className="xl-max-w-[1100px] flex max-w-[90%] basis-full flex-col flex-wrap justify-center rounded-xl md:flex-row md:items-center md:bg-white"
           id="search_spot"
+          onSubmit={onSubmit}
         >
           <FormInput
             myLabel={<Label myHtmlFor="coord"> Zone Géographique</Label>}
-            myInput={<input placeholder="Où veux-tu plonger?" id="coord" />}
+            myInput={
+              <PlaceAutocomplete
+                onPlaceSelect={onPlaceSelect}
+                onChange={onChangePlaceField}
+                placeholder="Où veux-tu plonger?"
+              >
+                {placeField}
+              </PlaceAutocomplete>
+            }
           />
           <FormInput
             myLabel={<Label myHtmlFor="label">Niveau recommandé</Label>}
             myInput={
               <select id="level">
-                <option value="all">Tous niveaux</option>
-                <option value="easy">Facile</option>
-                <option value="medium">Intermédiaire</option>
-                <option value="hard">Avancé</option>
+                {levelOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             }
           />
+          <select id="rad" defaultValue="9" className="hidden">
+            <option value="9" />
+          </select>
           <div className="my-2 flex justify-center rounded-xl bg-search-gradient px-5 py-3 text-white md:mr-2 md:rounded-lg">
             <button>
               <FontAwesomeIcon className="pr-2" icon={faMagnifyingGlass} />
@@ -35,42 +54,6 @@ export default function HomeSearchBar() {
           </div>
         </form>
       </div>
-
-      {/* <div>
-        <form id="searchBarBig">
-          <div>
-            <div>
-              <label htmlFor="areaQuery">
-                <div>Zone Géographique</div>
-                <input
-                  type="text"
-                  name="areaQuery"
-                  id="zoneQueryAutocomplete"
-                  placeholder="Où veux-tu plonger?"
-                />
-              </label>
-            </div>
-
-            <div>
-              <label htmlFor="keyWordQuery">
-                <div>Niveau recommendé</div>
-                <select name="keyWordQuery">
-                  <option value="all">Tous niveaux</option>
-                  <option value="easy">Facile</option>
-                  <option value="medium">Intermédiaire</option>
-                  <option value="hard">Avancé</option>
-                </select>
-              </label>
-            </div>
-
-            <div>
-              <button type="submit">
-                <img alt="" /> Rechercher
-              </button>
-            </div>
-          </div>
-        </form>
-      </div> */}
     </>
   );
 }


### PR DESCRIPTION
# Goal

- User can search spots
    - by location
    - by difficulty level
- Click on a search result redirects to spot page
- Home page search bar triggers search

### no scope

- Later
    - keywords
    - fauna / flora
- Map to visualize → [[Map-based search](https://www.notion.so/Map-based-search-442d09ddf57b421984dff2bf97c5d11a?pvs=21)](https://www.notion.so/Map-based-search-442d09ddf57b421984dff2bf97c5d11a?pvs=21)

# Acceptance Criteria

### General

- A user search queries the entire database and returns all matching results, except for published=False
- Results are displayed following a result template
- User can update search query and make another search from search result page
- A search location center (in terms of lat and lng) is defined by an autocomplete result from a third-party location search api (eg: Google Location API)

### Search parameters

- A latitude, longitude and radius are required to start a search
- extra constraints, such as keywords may be used
    - for now only difficulty level.